### PR TITLE
T787: Fix typo in opennhrp-script

### DIFF
--- a/etc/opennhrp-script
+++ b/etc/opennhrp-script
@@ -24,7 +24,7 @@ peer-up)
 	echo "Create link from $NHRP_SRCADDR ($NHRP_SRCNBMA) to $NHRP_DESTADDR ($NHRP_DESTNBMA)"
 	if [[ ( ${_type} == "spoke" ) && ( -e ${_strongswan_pid} ) ]]; then
 		if grep "${NHRP_SRCADDR}" "${_nhrp_ipsec}"; then
-			swanctl -t -S $NHRP_SRCNBMA -R $NHRP_DESTNBMA /dev/null 2>&1
+			swanctl -t -S $NHRP_SRCNBMA -R $NHRP_DESTNBMA > /dev/null 2>&1
 			swanctl -i -c dmvpn -S $NHRP_SRCNBMA -R $NHRP_DESTNBMA || exit 1
 		fi
 	fi


### PR DESCRIPTION
This is a breaking typo/bug and needs to be fixed to allow opennhrp to succeed in configuring ipsec tunnels.